### PR TITLE
fix(ForeignProxy): remove governance

### DIFF
--- a/contracts/deploy/002_foreign_proxy.js
+++ b/contracts/deploy/002_foreign_proxy.js
@@ -51,15 +51,11 @@ async function deployForeignProxy({ deployments, getChainId, ethers, config }) {
     const homeProxy = ethers.getCreateAddress(transaction);
     console.log(`Home proxy: ${homeProxy}`);
 
-    // Initially have the deployer as governor, and change it later
-    const governor = (await ethers.getSigners())[0].address;
-
     const foreignProxy = await deploy("RealitioForeignProxyRedStone", {
         from: account.address,
         args: [
             messenger,
             homeProxy,
-            governor,
             arbitrator,
             arbitratorExtraData,
             metaEvidence, [winnerMultiplier, loserMultiplier, loserAppealPeriodMultiplier],
@@ -76,7 +72,6 @@ async function deployForeignProxy({ deployments, getChainId, ethers, config }) {
         constructorArguments: [
             messenger,
             homeProxy,
-            governor,
             arbitrator,
             arbitratorExtraData,
             metaEvidence, [winnerMultiplier, loserMultiplier, loserAppealPeriodMultiplier],


### PR DESCRIPTION
Governance removed to avoid overengineering. In case a change of the parameters is needed the contract needs to be redeployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified contract architecture by removing governor-related functionality
	- Made several contract variables immutable
	- Streamlined dispute management logic

- **New Features**
	- Added a constant `META_EVIDENCE_ID` set to zero

- **Bug Fixes**
	- Updated dispute details retrieval mechanism
	- Removed redundant arbitration request parameters

- **Tests**
	- Removed governance-related test scenarios
	- Updated test methods to reflect contract changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->